### PR TITLE
Adapt this Action to run via the workflow_run event

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,38 @@ jobs:
           clang_tidy_fixes: fixes.yaml
 ```
 
+If you want to trigger the Action using the `workflow_run` event to run analysis on pull requests
+from forks in a
+[secure manner](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/),
+then you can try the following:
+
+```yaml
+name: Post static analysis results
+
+on:
+  workflow_run:
+    # Workflow that should provide the results of the analysis via artifact
+    workflows: [ "Static analysis" ]
+    types: [ completed ]
+
+jobs:
+  clang-tidy-results:
+    # Trigger the job only if previous workflow completed successfully
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-20.04
+    steps:
+      #
+      # In the previous steps you will need to download and extract the artifact with the
+      # fixes.yaml file and set the pr_id environment variable to the pull request id
+      #
+      - name: Run clang-tidy-pr-comments action
+        uses: platisd/clang-tidy-pr-comments@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clang_tidy_fixes: fixes.yaml
+          pull_request_id: ${{ env.pr_id }}
+```
+
 
 [clang-tidy-8 support]: https://img.shields.io/badge/clang--tidy-8-green
 [clang-tidy-9 support]: https://img.shields.io/badge/clang--tidy-9-green

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   clang_tidy_fixes:
     description: 'Path to the clang-tidy fixes YAML file'
     required: true
+  pull_request_id:
+    description: 'Pull request id (otherwise attempt to extract it from the GitHub metadata)'
+    default: ''
   request_changes:
     description: 'Request changes if there are clang-tidy issues (otherwise leave a comment)'
     default: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 set -xeu
 
-pull_request_id=$(cat "$GITHUB_EVENT_PATH" | jq 'if (.issue.number != null) then .issue.number else .number end')
+if [ -z "$INPUT_PULL_REQUEST_ID" ]; then
+  pull_request_id=$(cat "$GITHUB_EVENT_PATH" | jq 'if (.issue.number != null) then .issue.number else .number end')
 
-if [ $pull_request_id == "null" ]; then
-  echo "Could not find a pull request ID. Is this a pull request?"
-  exit 0
+  if [ "$pull_request_id" == "null" ]; then
+    echo "Could not find a pull request ID. Is this a pull request?"
+    exit 0
+  fi
+else
+  pull_request_id="$INPUT_PULL_REQUEST_ID"
 fi
 
 repository_name=$(basename $GITHUB_REPOSITORY)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,16 +12,16 @@ else
   pull_request_id="$INPUT_PULL_REQUEST_ID"
 fi
 
-repository_name=$(basename $GITHUB_REPOSITORY)
+repository_name="$(basename "$GITHUB_REPOSITORY")"
 recreated_runner_dir="/home/runner/work/$repository_name"
-mkdir -p $recreated_runner_dir
+mkdir -p "$recreated_runner_dir"
 recreated_repo_dir="$recreated_runner_dir/$repository_name"
 
-ln -s $(pwd) $recreated_repo_dir
+ln -s "$(pwd)" "$recreated_repo_dir"
 
-cd $recreated_repo_dir
+cd "$recreated_repo_dir"
 
 eval python3 /action/run_action.py \
-  --clang-tidy-fixes $INPUT_CLANG_TIDY_FIXES \
-  --pull-request-id $pull_request_id \
-  --repository-root $recreated_repo_dir
+  --clang-tidy-fixes "$INPUT_CLANG_TIDY_FIXES" \
+  --pull-request-id "$pull_request_id" \
+  --repository-root "$recreated_repo_dir"


### PR DESCRIPTION
Hi @platisd thank you very much for this Action! I would like to suggest a little tweak for it to be able to use it in workflow chains (running via the `workflow_run` event) in schemes like the one described here:

https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

The reason for this is that I would like to use this Action in a safe manner when I use clang-tidy to check pull requests from forks.