### PR TITLE
README.md: add live examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Please note the following:
   This means that there may be more warnings in your project. Make sure you fix them *before* starting to
   use this Action to ensure new warnings will not be introduced in the future.
 * This Action *respects* existing comments and doesn't repeat the same warnings for the same line (no spam).
+* This Action allows analysis to be performed *separately* from the posting of the analysis results (using
+  separate workflows with different privileges), which
+  [allows you to safely analyze pull requests from forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
+  (see examples below).
 
 ### Supported clang-tidy versions
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ A GitHub Action to post `clang-tidy` warnings and suggestions as review comments
 
 ![action preview](https://i.imgur.com/lQiFdT9.png)
 
+## Table of contents
+
+* [What](#what)
+  * [Supported clang-tidy versions](#supported-clang-tidy-versions)
+* [How](#how)
+  * [Basic configuration example](#basic-configuration-example)
+  * [Triggering this Action manually](#triggering-this-action-manually)
+  * [Using this Action to safely perform analysis of pull requests from forks](#using-this-action-to-safely-perform-analysis-of-pull-requests-from-forks)
+
 ## What
 
 `platisd/clang-tidy-pr-comments` is a GitHub Action that utilizes the *exported fixes* of
@@ -20,8 +29,8 @@ misconfigured by you, due to a bug (please contact me if that's the case) or the
 
 Please note the following:
 
-* It will **not** run `clang-tidy` for you. You are responsible for doing that and then
-  supply the Action with the path to your generated report (see examples below). You can generate a
+* It will **not** run `clang-tidy` for you. You are responsible for doing that and then supply the Action with
+  the path to your generated report (see [examples](#how) below). You can generate a
   YAML report that includes *fixes* for a pull request using the following methods:
 
   * Using the `run-clang-tidy` utility script with the `-export-fixes` argument. This script usually
@@ -47,7 +56,7 @@ Please note the following:
 * This Action allows analysis to be performed *separately* from the posting of the analysis results (using
   separate workflows with different privileges), which
   [allows you to safely analyze pull requests from forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
-  (see examples below).
+  (see [example](#using-this-action-to-safely-perform-analysis-of-pull-requests-from-forks) below).
 
 ### Supported clang-tidy versions
 
@@ -63,6 +72,8 @@ YAML files containing generated fixes by the following `clang-tidy` versions are
 Since this action comments on files changed in pull requests, naturally, it can be only run
 on `pull_request` events. That being said, if it happens to be triggered in a different context,
 e.g. a `push` event, it will **not** run and fail *softly* by returning a *success* code.
+
+### Basic configuration example
 
 A basic configuration for the `platisd/clang-tidy-pr-comments` action (for a `CMake`-based project
 using the `clang-tidy-diff.py` script) can be seen below:
@@ -108,7 +119,9 @@ jobs:
         suggestions_per_comment: 10
 ```
 
-If you want to trigger the Action manually, i.e. by leaving a comment with a particular *keyword*
+### Triggering this Action manually
+
+If you want to trigger this Action manually, i.e. by leaving a comment with a particular *keyword*
 in the pull request, then you can try the following:
 
 ```yaml
@@ -145,6 +158,8 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         clang_tidy_fixes: clang-tidy-result/fixes.yml
 ```
+
+### Using this Action to safely perform analysis of pull requests from forks
 
 If you want to trigger the Action using the `workflow_run` event to run analysis on pull requests
 from forks in a

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ jobs:
       run: |
         git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Run clang-tidy-pr-comments action
+      # Don't run this Action if fixes.yml doesn't exist - clang-tidy may not generate it in some cases
       if: ${{ hashFiles( 'clang-tidy-result/fixes.yml' ) != '' }}
       uses: platisd/clang-tidy-pr-comments@master
       with:
@@ -137,6 +138,7 @@ jobs:
       run: |
         git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Run clang-tidy-pr-comments action
+      # Don't run this Action if fixes.yml doesn't exist - clang-tidy may not generate it in some cases
       if: ${{ hashFiles( 'clang-tidy-result/fixes.yml' ) != '' }}
       uses: platisd/clang-tidy-pr-comments@master
       with:
@@ -256,6 +258,7 @@ jobs:
         mkdir clang-tidy-result
         unzip clang-tidy-result.zip -d clang-tidy-result
     - name: Run clang-tidy-pr-comments action
+      # Don't run this Action if fixes.yml doesn't exist - clang-tidy may not generate it in some cases
       if: ${{ hashFiles( 'clang-tidy-result/fixes.yml' ) != '' }}
       uses: platisd/clang-tidy-pr-comments@master
       with:

--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ misconfigured by you, due to a bug (please contact me if that's the case) or the
 Please note the following:
 * It will **not** run `clang-tidy` for you. You are responsible for doing that and then
   supply the Action with the path to your generated report (see examples below).<br>
-  Specifically, the YAML report that includes the *fixes* is generated via the `-export-fixes` argument
-  to the `run-clang-tidy` utility script. Alternatively, you may use `--export-fixes` with `clang-tidy`
+  Specifically, a YAML report that includes *fixes* for the pull request can be generated using
+  the `clang-tidy-diff.py` script with the `-export-fixes` argument. This script usually comes
+  with the `clang-tidy` packages. Alternatively, you may use `--export-fixes` with `clang-tidy`
   itself and then, in both cases, specify the path where you would like the report to be exported.<br>
   The very same path should be supplied to the GitHub Action.
 * It will *only* comment on files and lines changed in the pull request. This is due to GitHub not allowing
   comments on other files outside the pull request `diff`.
-  This means that there may be more warnings in your project. Make sure you fix
-  them *before* starting to use this Action to ensure new warnings will not be introduced in the future.
+  This means that there may be more warnings in your project. Make sure you fix them *before* starting to
+  use this Action to ensure new warnings will not be introduced in the future.
 * This Action *respects* existing comments and doesn't repeat the same warnings for the same line (no spam).
 
 ### Supported clang-tidy versions
@@ -46,7 +47,8 @@ Since this action comments on files changed in pull requests, naturally, it can 
 on `pull_request` events. That being said, if it happens to be triggered in a different context,
 e.g. a `push` event, it will **not** run and fail *softly* by returning a *success* code.
 
-A basic configuration for the `platisd/clang-tidy-pr-comments` action can be seen below:
+A basic configuration for the `platisd/clang-tidy-pr-comments` action (for a `CMake`-based project
+using the `clang-tidy-diff.py` script) can be seen below:
 
 ```yaml
 name: Static analysis
@@ -57,25 +59,35 @@ jobs:
   clang-tidy:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Build project and/or unit tests
-        run: ./your-build-script.sh
-      - name: Run clang-tidy
-        run: ./your-clang-tidy-script.sh --fixes-path fixes.yaml
-      - name: Run clang-tidy-pr-comments action
-        uses: platisd/clang-tidy-pr-comments@master
-        with:
-          # The GitHub token (or a personal access token)
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # The path to the clang-tidy fixes generated previously
-          clang_tidy_fixes: fixes.yaml
-          # Optionally set to true if you want the Action to request
-          # changes in case warnings are found
-          request_changes: true
-          # Optionally set the number of comments per review
-          # to avoid GitHub API timeouts for heavily loaded
-          # pull requests
-          suggestions_per_comment: 10
+    - uses: actions/checkout@v2
+    - name: Install clang-tidy
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-tidy
+    - name: Prepare compile_commands.json
+      run: |
+        cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - name: Create results directory
+      run: |
+        mkdir clang-tidy-result
+    - name: Analyze
+      run: |
+        git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+    - name: Run clang-tidy-pr-comments action
+      if: ${{ hashFiles( 'clang-tidy-result/fixes.yml' ) != '' }}
+      uses: platisd/clang-tidy-pr-comments@master
+      with:
+        # The GitHub token (or a personal access token)
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        # The path to the clang-tidy fixes generated previously
+        clang_tidy_fixes: clang-tidy-result/fixes.yml
+        # Optionally set to true if you want the Action to request
+        # changes in case warnings are found
+        request_changes: true
+        # Optionally set the number of comments per review
+        # to avoid GitHub API timeouts for heavily loaded
+        # pull requests
+        suggestions_per_comment: 10
 ```
 
 If you want to trigger the Action manually, i.e. by leaving a comment with a particular *keyword*
@@ -90,53 +102,150 @@ on: issue_comment
 jobs:
   clang-tidy:
     # Trigger the job only when someone comments: run_clang_tidy
-    if: github.event.issue.pull_request && contains(github.event.comment.body, 'run_clang_tidy')
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'run_clang_tidy') }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Build project and/or unit tests
-        run: ./your-build-script.sh
-      - name: Run clang-tidy
-        run: ./your-clang-tidy-script.sh --fixes-path fixes.yaml
-      - name: Run clang-tidy-pr-comments action
-        uses: platisd/clang-tidy-pr-comments@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          clang_tidy_fixes: fixes.yaml
+    - uses: actions/checkout@v2
+    - name: Install clang-tidy
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-tidy
+    - name: Prepare compile_commands.json
+      run: |
+        cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - name: Create results directory
+      run: |
+        mkdir clang-tidy-result
+    - name: Analyze
+      run: |
+        git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+    - name: Run clang-tidy-pr-comments action
+      if: ${{ hashFiles( 'clang-tidy-result/fixes.yml' ) != '' }}
+      uses: platisd/clang-tidy-pr-comments@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        clang_tidy_fixes: clang-tidy-result/fixes.yml
 ```
 
 If you want to trigger the Action using the `workflow_run` event to run analysis on pull requests
 from forks in a
 [secure manner](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/),
-then you can try the following:
+then you can use the following combination of workflows:
 
 ```yaml
-name: Post static analysis results
+# Insecure workflow with limited permissions that should provide analysis results through an artifact
+name: Static analysis
+
+on: pull_request
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install clang-tidy
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-tidy
+    - name: Prepare compile_commands.json
+      run: |
+        cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - name: Create results directory
+      run: |
+        mkdir clang-tidy-result
+    - name: Analyze
+      run: |
+        git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+    - name: Save PR metadata
+      run: |
+        echo ${{ github.event.number }} > clang-tidy-result/pr-id.txt
+        echo ${{ github.event.pull_request.head.repo.full_name }} > clang-tidy-result/pr-head-repo.txt
+        echo ${{ github.event.pull_request.head.ref }} > clang-tidy-result/pr-head-ref.txt
+    - uses: actions/upload-artifact@v2
+      with:
+        name: clang-tidy-result
+        path: clang-tidy-result/
+```
+
+```yaml
+# Secure workflow with access to repository secrets and GitHub token for posting analysis results
+name: Post the static analysis results
 
 on:
   workflow_run:
-    # Workflow that should provide the results of the analysis via artifact
     workflows: [ "Static analysis" ]
     types: [ completed ]
 
 jobs:
   clang-tidy-results:
-    # Trigger the job only if previous workflow completed successfully
+    # Trigger the job only if the previous (insecure) workflow completed successfully
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-20.04
     steps:
-      #
-      # In the previous steps you will need to download and extract the artifact with the
-      # fixes.yaml file and set the pr_id environment variable to the pull request id
-      #
-      - name: Run clang-tidy-pr-comments action
-        uses: platisd/clang-tidy-pr-comments@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          clang_tidy_fixes: fixes.yaml
-          pull_request_id: ${{ env.pr_id }}
+    - name: Download analysis results
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          let artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+          });
+          let matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-result"
+          })[0];
+          let download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: "zip",
+          });
+          let fs = require("fs");
+          fs.writeFileSync("${{github.workspace}}/clang-tidy-result.zip", Buffer.from(download.data));
+    - name: Set environment variables
+      run: |
+        mkdir clang-tidy-result
+        unzip clang-tidy-result.zip -d clang-tidy-result
+        echo "pr_id=$(cat clang-tidy-result/pr-id.txt)" >> $GITHUB_ENV
+        echo "pr_head_repo=$(cat clang-tidy-result/pr-head-repo.txt)" >> $GITHUB_ENV
+        echo "pr_head_ref=$(cat clang-tidy-result/pr-head-ref.txt)" >> $GITHUB_ENV
+    - uses: actions/checkout@v2
+      with:
+        repository: ${{ env.pr_head_repo }}
+        ref: ${{ env.pr_head_ref }}
+        persist-credentials: false
+    - name: Redownload analysis results
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+          let artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+          });
+          let matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-result"
+          })[0];
+          let download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: "zip",
+          });
+          let fs = require("fs");
+          fs.writeFileSync("${{github.workspace}}/clang-tidy-result.zip", Buffer.from(download.data));
+    - name: Extract analysis results
+      run: |
+        mkdir clang-tidy-result
+        unzip clang-tidy-result.zip -d clang-tidy-result
+    - name: Run clang-tidy-pr-comments action
+      if: ${{ hashFiles( 'clang-tidy-result/fixes.yml' ) != '' }}
+      uses: platisd/clang-tidy-pr-comments@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        clang_tidy_fixes: clang-tidy-result/fixes.yml
+        pull_request_id: ${{ env.pr_id }}
 ```
-
 
 [clang-tidy-8 support]: https://img.shields.io/badge/clang--tidy-8-green
 [clang-tidy-9 support]: https://img.shields.io/badge/clang--tidy-9-green

--- a/README.md
+++ b/README.md
@@ -19,18 +19,31 @@ leave a comment without blocking the pull request from being merged. It should f
 misconfigured by you, due to a bug (please contact me if that's the case) or the GitHub API acting up.
 
 Please note the following:
+
 * It will **not** run `clang-tidy` for you. You are responsible for doing that and then
-  supply the Action with the path to your generated report (see examples below).<br>
-  Specifically, a YAML report that includes *fixes* for the pull request can be generated using
-  the `clang-tidy-diff.py` script with the `-export-fixes` argument. This script usually comes
-  with the `clang-tidy` packages. Alternatively, you may use `--export-fixes` with `clang-tidy`
-  itself and then, in both cases, specify the path where you would like the report to be exported.<br>
-  The very same path should be supplied to the GitHub Action.
+  supply the Action with the path to your generated report (see examples below). You can generate a
+  YAML report that includes *fixes* for a pull request using the following methods:
+
+  * Using the `run-clang-tidy` utility script with the `-export-fixes` argument. This script usually
+    comes with the `clang-tidy` packages. You can use it to run checks *for the entire codebase* of a
+    project at once.
+
+  * Using the `clang-tidy-diff` utility script with the `-export-fixes` argument. This script also usually
+    comes with the `clang-tidy` packages, and and it can be used to run checks only for code fragments that
+    *have been changed* in a specific pull request.
+
+  * Alternatively, you may use `--export-fixes` with `clang-tidy` itself in your own script.
+
+  In any case, specify the path where you would like the report to be exported. The very same path should
+  be supplied to this Action.
+
 * It will *only* comment on files and lines changed in the pull request. This is due to GitHub not allowing
   comments on other files outside the pull request `diff`.
   This means that there may be more warnings in your project. Make sure you fix them *before* starting to
   use this Action to ensure new warnings will not be introduced in the future.
+
 * This Action *respects* existing comments and doesn't repeat the same warnings for the same line (no spam).
+
 * This Action allows analysis to be performed *separately* from the posting of the analysis results (using
   separate workflows with different privileges), which
   [allows you to safely analyze pull requests from forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)


### PR DESCRIPTION
Hi @platisd since I use your Action in a real project hosted on the GitHub, I want to offer to share some real-world examples of workflows used to run your Action, so that end users understand that running `clang-tidy` manually is not so difficult, and also so that they have a real example before their eyes instead of abstract `your-clang-tidy-script.sh` (and so they can even cut-and-paste it to use in their own workflows).

Also I would like to highlight the feature that allows to analyze PRs from forks in a safe manner, because it really is a "killer feature" of this Action. Other Actions are usually combined "all-in-one" and they just can't do it. And this is a very important feature for a popular GitHub project with many external contributors.