### PR TITLE
Don't fail if the clang-tidy fixes file doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ e.g. a `push` event, it will **not** run and fail *softly* by returning a *succe
 ### Basic configuration example
 
 A basic configuration for the `platisd/clang-tidy-pr-comments` action (for a `CMake`-based project
-using the `clang-tidy-diff.py` script) can be seen below:
+using the `clang-tidy-diff` script) can be seen below:
 
 ```yaml
 name: Static analysis
@@ -102,8 +102,6 @@ jobs:
       run: |
         git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Run clang-tidy-pr-comments action
-      # Don't run this Action if fixes.yml doesn't exist - clang-tidy may not generate it in some cases
-      if: ${{ hashFiles( 'clang-tidy-result/fixes.yml' ) != '' }}
       uses: platisd/clang-tidy-pr-comments@master
       with:
         # The GitHub token (or a personal access token)
@@ -151,8 +149,6 @@ jobs:
       run: |
         git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Run clang-tidy-pr-comments action
-      # Don't run this Action if fixes.yml doesn't exist - clang-tidy may not generate it in some cases
-      if: ${{ hashFiles( 'clang-tidy-result/fixes.yml' ) != '' }}
       uses: platisd/clang-tidy-pr-comments@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -161,7 +157,7 @@ jobs:
 
 ### Using this Action to safely perform analysis of pull requests from forks
 
-If you want to trigger the Action using the `workflow_run` event to run analysis on pull requests
+If you want to trigger this Action using the `workflow_run` event to run analysis on pull requests
 from forks in a
 [secure manner](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/),
 then you can use the following combination of workflows:
@@ -273,8 +269,6 @@ jobs:
         mkdir clang-tidy-result
         unzip clang-tidy-result.zip -d clang-tidy-result
     - name: Run clang-tidy-pr-comments action
-      # Don't run this Action if fixes.yml doesn't exist - clang-tidy may not generate it in some cases
-      if: ${{ hashFiles( 'clang-tidy-result/fixes.yml' ) != '' }}
       uses: platisd/clang-tidy-pr-comments@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ ln -s "$(pwd)" "$recreated_repo_dir"
 cd "$recreated_repo_dir"
 
 if [ ! -f "$INPUT_CLANG_TIDY_FIXES" ]; then
-  echo "Could not find the clang-tidy fixes file. Perhaps it wasn't created?"
+  echo "Could not find the clang-tidy fixes file '$INPUT_CLANG_TIDY_FIXES'. Perhaps it wasn't created?"
   exit 0
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -xeu
+
+set -eu
 
 if [ -z "$INPUT_PULL_REQUEST_ID" ]; then
   pull_request_id=$(cat "$GITHUB_EVENT_PATH" | jq 'if (.issue.number != null) then .issue.number else .number end')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ if [ -z "$INPUT_PULL_REQUEST_ID" ]; then
   pull_request_id=$(cat "$GITHUB_EVENT_PATH" | jq 'if (.issue.number != null) then .issue.number else .number end')
 
   if [ "$pull_request_id" == "null" ]; then
-    echo "Could not find a pull request ID. Is this a pull request?"
+    echo "Could not find the pull request ID. Is this a pull request?"
     exit 0
   fi
 else
@@ -20,6 +20,11 @@ recreated_repo_dir="$recreated_runner_dir/$repository_name"
 ln -s "$(pwd)" "$recreated_repo_dir"
 
 cd "$recreated_repo_dir"
+
+if [ ! -f "$INPUT_CLANG_TIDY_FIXES" ]; then
+  echo "Could not find the clang-tidy fixes file. Perhaps it wasn't created?"
+  exit 0
+fi
 
 eval python3 /action/run_action.py \
   --clang-tidy-fixes "$INPUT_CLANG_TIDY_FIXES" \


### PR DESCRIPTION
Following the discussion in #9.