### PR TITLE
Don't use eval to run the run_action.py

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ if [ ! -f "$INPUT_CLANG_TIDY_FIXES" ]; then
   exit 0
 fi
 
-python3 /action/run_action.py \
+/action/run_action.py \
   --clang-tidy-fixes "$INPUT_CLANG_TIDY_FIXES" \
   --pull-request-id "$pull_request_id" \
   --repository-root "$recreated_repo_dir"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -eu
 
 if [ -z "$INPUT_PULL_REQUEST_ID" ]; then
-  pull_request_id=$(cat "$GITHUB_EVENT_PATH" | jq 'if (.issue.number != null) then .issue.number else .number end')
+  pull_request_id="$(jq "if (.issue.number != null) then .issue.number else .number end" < "$GITHUB_EVENT_PATH")"
 
   if [ "$pull_request_id" == "null" ]; then
     echo "Could not find the pull request ID. Is this a pull request?"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ if [ ! -f "$INPUT_CLANG_TIDY_FIXES" ]; then
   exit 0
 fi
 
-eval python3 /action/run_action.py \
+python3 /action/run_action.py \
   --clang-tidy-fixes "$INPUT_CLANG_TIDY_FIXES" \
   --pull-request-id "$pull_request_id" \
   --repository-root "$recreated_repo_dir"

--- a/run_action.py
+++ b/run_action.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os


### PR DESCRIPTION
Hi @platisd I just noticed that `eval` is used to run the `run_action.py` and in this PR I would like to suggest NOT to use it. `eval` is very dangerous and should be used with caution. Consider this example:

```
$ INPUT_CLANG_TIDY_FIXES='OK; echo OK'
$ echo "$INPUT_CLANG_TIDY_FIXES"
OK; echo OK
```

So far so good. Let's run the same command using `eval`:

```
$ eval echo "$INPUT_CLANG_TIDY_FIXES"
OK
OK
```

We just got a command injection. `eval` may be used, for example, if we have some variable names in a command that are not known at the time of writing the script, but I don't see any reason to use it here.

Also I propose not to use `cat` when we may just use input redirection and use `env python3` in a shebang of the `run_action.py` instead of using explicit `python3` in the `entrypoint.sh`.