### PR TITLE
Properly deal with markdown in clang-tidy comments, minor fixes suggested by pylint

### DIFF
--- a/run_action.py
+++ b/run_action.py
@@ -20,6 +20,15 @@ def chunks(lst, n):
         yield lst[i : i + n]
 
 
+def markdown(s):
+    # Escape markdown characters
+    md_chars = "\\`*_{}[]<>()#+-.!|"
+    for ch in md_chars:
+        s = s.replace(ch, "\\" + ch)
+
+    return s
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Pull request comments from clang-tidy reports action runner"
@@ -228,9 +237,9 @@ def main():
         if line_number in changed_lines:
             review_comment_body = (
                 ":warning: **"
-                + diagnostic["DiagnosticName"]
+                + markdown(diagnostic["DiagnosticName"])
                 + "** :warning:\n"
-                + diagnostic["DiagnosticMessage"]["Message"]
+                + markdown(diagnostic["DiagnosticMessage"]["Message"])
                 + suggestions
             )
             review_comments.append(

--- a/run_action.py
+++ b/run_action.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 
-import sys
-import os
-import json
-import requests
 import argparse
-import yaml
-import re
 import itertools
+import json
+import os
 import posixpath
+import re
+import sys
 import time
+
+import requests
+import yaml
 
 
 def chunks(lst, n):

--- a/run_action.py
+++ b/run_action.py
@@ -21,10 +21,32 @@ def chunks(lst, n):
 
 
 def markdown(s):
-    # Escape markdown characters
     md_chars = "\\`*_{}[]<>()#+-.!|"
-    for ch in md_chars:
-        s = s.replace(ch, "\\" + ch)
+
+
+    def escape_chars(s):
+        for ch in md_chars:
+            s = s.replace(ch, "\\" + ch)
+
+        return s
+
+
+    def unescape_chars(s):
+        for ch in md_chars:
+            s = s.replace("\\" + ch, ch)
+
+        return s
+
+
+    # Escape markdown characters
+    s = escape_chars(s)
+    # Decorate quoted symbols as code
+    s = re.sub(
+        "'([^']*)'",
+        lambda match:
+            "`` " + unescape_chars(match.group(1)) + " ``",
+        s
+    )
 
     return s
 

--- a/run_action.py
+++ b/run_action.py
@@ -10,7 +10,6 @@ import re
 import itertools
 import posixpath
 import time
-from string import Template
 
 
 def chunks(lst, n):

--- a/run_action.py
+++ b/run_action.py
@@ -151,7 +151,6 @@ def main():
         ]
 
     repository_root = args.repository_root + "/"
-    clang_tidy_fixes_for_available_files = list()
     # Normalize paths
     for diagnostic in clang_tidy_fixes["Diagnostics"]:
         # diagnostic = d["DiagnosticMessage"] if "DiagnosticMessage" in d.keys() else d


### PR DESCRIPTION
Hi @platisd I would like to propose another PR in which:

* An issue with markdown formatting in clang-tidy reviews should be fixed now. Consider the difference between comments in [this](https://github.com/oleg-derevenetz/fheroes2/pull/46) pull request (without proposed changes) and [this](https://github.com/oleg-derevenetz/fheroes2/pull/45) (with these changes). In the first case the `#include <cmath>` part is displayed incorrectly;
* Quoted symbols are now decorated as code (it looks funny);
* Some cosmetic issues found by `pylint` are fixed (unused variable, unused import and wrong order of imports).