### PR TITLE
Properly work with multiple suggested changes for one diagnostic entry, fix off-by-one error in the offset calculation

### DIFF
--- a/run_action.py
+++ b/run_action.py
@@ -252,7 +252,7 @@ def main():
                 character_counter += len(source_file_line)
                 newlines_until_offset += 1
                 # Check if we have found the line with the warning
-                if character_counter >= diagnostic["FileOffset"]:
+                if character_counter > diagnostic["FileOffset"]:
                     beginning_of_line = character_counter - len(source_file_line)
                     if "ReplacementText" in diagnostic:
                         # The offset from the beginning of line until the warning

--- a/run_action.py
+++ b/run_action.py
@@ -84,7 +84,7 @@ def main():
     )
     github_api_url = os.environ.get("GITHUB_API_URL")
 
-    pull_request_files = []
+    pull_request_files = list()
     # Request a maximum of 100 pages (3000 files)
     for page_num in range(1, 101):
         pull_files_url = "%s/repos/%s/pulls/%d/files?page=%d" % (
@@ -113,7 +113,7 @@ def main():
         if len(pull_files_chunk) == 0:
             break
 
-        pull_request_files += pull_files_chunk
+        pull_request_files.extend(pull_files_chunk)
 
     files_and_lines_available_for_comments = dict()
     for pull_request_file in pull_request_files:
@@ -295,7 +295,7 @@ def main():
         return 0
 
     # Load the existing review comments
-    existing_pull_request_comments = []
+    existing_pull_request_comments = list()
     # Request a maximum of 100 pages (3000 comments)
     for page_num in range(1, 101):
         pull_comments_url = "%s/repos/%s/pulls/%d/comments?page=%d" % (
@@ -324,7 +324,7 @@ def main():
         if len(pull_comments_chunk) == 0:
             break
 
-        existing_pull_request_comments += pull_comments_chunk
+        existing_pull_request_comments.extend(pull_comments_chunk)
 
     # Exclude already posted comments
     for comment in existing_pull_request_comments:


### PR DESCRIPTION
Hi @platisd it turns out that this Action can't work properly with `fixes.yml` files that contain multiple `Replacements` entries for single `DiagnosticMessage` which are related to different files (or even to different lines of the same file), like this one:

```
Diagnostics:
- BuildDirectory: /home/runner/work/fheroes2/fheroes2/build/src/fheroes2
  DiagnosticMessage:
    FileOffset: 6964
    FilePath: /home/runner/work/fheroes2/fheroes2/src/fheroes2/army/army_bar.cpp
    Message: return type 'const fheroes2::Sprite' is 'const'-qualified at the top
      level, which may reduce code readability without improving const correctness
    Replacements:
    - FilePath: /home/runner/work/fheroes2/fheroes2/src/fheroes2/army/army_bar.cpp
      Length: 6
      Offset: 6964
      ReplacementText: ''
    - FilePath: /home/runner/work/fheroes2/fheroes2/src/fheroes2/army/army_bar.h
      Length: 6
      Offset: 1883
      ReplacementText: ''
  DiagnosticName: readability-const-return-type
  Level: Warning
  Ranges:
  - FileOffset: 6964
    FilePath: /home/runner/work/fheroes2/fheroes2/src/fheroes2/army/army_bar.cpp
    Length: 5
- BuildDirectory: /home/runner/work/fheroes2/fheroes2/build/src/fheroes2
  DiagnosticMessage:
    FileOffset: 6996
    FilePath: /home/runner/work/fheroes2/fheroes2/src/fheroes2/army/army_bar.cpp
    Message: method 'GetUpgradeButton' can be made static
    Replacements:
    - FilePath: /home/runner/work/fheroes2/fheroes2/src/fheroes2/army/army_bar.h
      Length: 0
      Offset: 1883
      ReplacementText: 'static '
  DiagnosticName: readability-convert-member-functions-to-static
  Level: Warning
- BuildDirectory: /home/runner/work/fheroes2/fheroes2/build/src/fheroes2
  DiagnosticMessage:
    FileOffset: 7589
    FilePath: /home/runner/work/fheroes2/fheroes2/src/fheroes2/army/army_bar.cpp
    Message: unused variable 'unused'
    Replacements: []
  DiagnosticName: clang-diagnostic-unused-variable
  Level: Error
MainSourceFile: ''
```

Here is how it [looks](https://github.com/oleg-derevenetz/fheroes2/pull/55). This PR is intended to fix this. My proposal is to create a separate entry for each `Replacement`. That's how the test PR [looks](https://github.com/oleg-derevenetz/fheroes2/pull/57) after this change. If you know specific cases when this approach may not work correctly - please let me know, I'll think about it once more.

Also this PR fixes the off-by-one error in the offset calculation when applying the replacement.