### PR TITLE
Add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,10 +6,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
-      - id: check-json
       - id: check-merge-conflict
-      - id: check-toml
-      - id: check-xml
       - id: check-yaml
       - id: detect-private-key
       - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+ci:
+  autofix_commit_msg: "ci(pre-commit): autofix"
+  autoupdate_commit_msg: "ci(pre-commit): autoupdate"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-xml
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]

--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
 branding:
-  icon: 'cpu'  
+  icon: 'cpu'
   color: 'green'


### PR DESCRIPTION
Added [pre-commit](https://pre-commit.com/) with minimum settings.

To check this automatically, you have to either:
- Install [pre-commit.ci](https://pre-commit.ci/) in this repository (Recommended)
- Add a workflow of [pre-commit action](https://github.com/pre-commit/action) (Deprecated)

You can consider other pre-commit hooks, my recommendations for this repository are:
- [markdownlint](https://github.com/DavidAnson/markdownlint)
- [Prettier](https://prettier.io/)
- [yamllint](https://github.com/adrienverge/yamllint)
- [shfmt](https://github.com/mvdan/sh)
- [isort](https://github.com/PyCQA/isort)
- [Black](https://github.com/psf/black)

If you are interested, I can add them.
See https://github.com/kenji-miyake/clang-tidy-pr-comments/pull/1 for how it works.
[This commit](https://github.com/kenji-miyake/clang-tidy-pr-comments/pull/1/commits/2a8132f2484ddaff4be310aab8850bbdbf536ed7) is the auto-formatting by `pre-commit.ci`.