### PR TITLE
Fix invalid formats of action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,13 +9,16 @@ inputs:
     required: true
   pull_request_id:
     description: 'Pull request id (otherwise attempt to extract it from the GitHub metadata)'
+    required: false
     default: ''
   request_changes:
     description: 'Request changes if there are clang-tidy issues (otherwise leave a comment)'
-    default: false
+    required: false
+    default: 'false'
   suggestions_per_comment:
     description: 'The number of suggestions per comment (smaller numbers work better for heavy pull requests)'
-    default: 10
+    required: false
+    default: '10'
 
 runs:
   using: 'docker'


### PR DESCRIPTION
According to https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions,
- The `required` key is `Required`.
- The values should be `string`.

![image](https://user-images.githubusercontent.com/31987104/153741937-6132e9af-f14d-438a-aa37-98097aecbedb.png)

Before this PR, my IDE shows errors like this.
![image](https://user-images.githubusercontent.com/31987104/153741958-6089c673-03bb-4715-aeb4-8928f5454e44.png)