### PR TITLE
Add release CI workflows

### DIFF
--- a/.github/workflows/actions-tagger.yaml
+++ b/.github/workflows/actions-tagger.yaml
@@ -1,0 +1,13 @@
+name: actions-tagger
+
+on:
+  release:
+    types:
+      - published
+      - edited
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@v2

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -1,0 +1,22 @@
+name: github-release
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Release to GitHub
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --draft \
+            --title "Release ${{ github.ref_name }}" \
+            --notes ""
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As explained in #17,
- `github-release.yaml` will prepare the release when a tag is published.
- `actions-tagger.yaml` will generate a `v1/v2/v3` tag when a release is published.