### PR TITLE
Feature: add `repo_path_prefix` argument for non-standard repo path.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'The number of suggestions per comment (smaller numbers work better for heavy pull requests)'
     required: false
     default: '10'
+  repo_path_prefix:
+    description: 'The path to repo when code is analyzed with clang-tidy; may set to "/__w" for users who run clang-tidy in a docker container'
+    required: false
+    default: '/home/runner/work'
 
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ else
 fi
 
 repository_name="$(basename "$GITHUB_REPOSITORY")"
-recreated_runner_dir="/home/runner/work/$repository_name"
+recreated_runner_dir="$INPUT_REPO_PATH_PREFIX/$repository_name"
 mkdir -p "$recreated_runner_dir"
 recreated_repo_dir="$recreated_runner_dir/$repository_name"
 


### PR DESCRIPTION
Probably fixes #23 by setting `repo_path_prefix` as `/__w` when using docker image for clang-tidy.
P.S. I found it hard to describe this argument and its usage; any suggestions are welcomed.