### PR TITLE
Fix parsing of patch sections containing multiple hunks

### DIFF
--- a/run_action.py
+++ b/run_action.py
@@ -132,7 +132,7 @@ def main():
         if "patch" not in pull_request_file:
             continue
 
-        git_line_tags = re.findall(r"^@@ -.*? +.*? @@", pull_request_file["patch"])
+        git_line_tags = re.findall(r"^@@ -.*? +.*? @@", pull_request_file["patch"], re.MULTILINE)
         # The result is something like ['@@ -101,8 +102,11 @@', '@@ -123,9 +127,7 @@']
         # We need to get it to a state like this: ['102,11', '127,7']
         lines_and_changes = [


### PR DESCRIPTION
Fix serious regression introduced by #28.

The thing is, each patch section in the PR metadata can contain multiple hunks, like this:

```
{'sha': 'd117538f1e6cbc2502c69de834a91b9e21e54c4f', [...] 'patch': '@@ -44,6 +44,40 @@\n \n namespace\n[...]\n@@ -129,16 +163,6 @@ namespace\n[...]'}
```

and without the `re.MULTILINE` flag special characters `^` and `$` match only at the beginning and at the end of the whole patch string respectively, and not at the beginning and the end of each line inside that string. As a result of incorrect parsing, we get the "Warnings found but none in lines changed by this pull request" [warning](https://github.com/ihhub/fheroes2/actions/runs/3238007362/jobs/5305733597#step:8:15) in cases where it shouldn't be.