### PR TITLE
Add new Clang-Tidy badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # clang-tidy pull request comments
-![clang-tidy-8 support] ![clang-tidy-9 support] ![clang-tidy-10 support] ![clang-tidy-11 support] ![clang-tidy-12 support]
+
+[![Clang-Tidy 8 support](https://img.shields.io/badge/clang--tidy-8-brightgreen)](https://releases.llvm.org/8.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html)
+[![Clang-Tidy 9 support](https://img.shields.io/badge/clang--tidy-9-brightgreen)](https://releases.llvm.org/9.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html)
+[![Clang-Tidy 10 support](https://img.shields.io/badge/clang--tidy-10-brightgreen)](https://releases.llvm.org/10.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html)
+[![Clang-Tidy 11 support](https://img.shields.io/badge/clang--tidy-11-brightgreen)](https://releases.llvm.org/11.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html)
+[![Clang-Tidy 12 support](https://img.shields.io/badge/clang--tidy-12-brightgreen)](https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html)
+[![Clang-Tidy 13 support](https://img.shields.io/badge/clang--tidy-13-brightgreen)](https://releases.llvm.org/13.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html)
+[![Clang-Tidy 14 support](https://img.shields.io/badge/clang--tidy-14-brightgreen)](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html)
 
 A GitHub Action to post `clang-tidy` warnings and suggestions as review comments on your pull request.
 


### PR DESCRIPTION
This action 100% works well with Clang-Tidy 14, and should also work with Clang-Tidy 13. Plus, the corresponding links to the documentation for the corresponding versions of Clang-Tidy have been added.