### PR TITLE
Still use UTF-8 for fixes.yml, use yaml.safe_load() instead of yaml.full_load()

### DIFF
--- a/run_action.py
+++ b/run_action.py
@@ -151,8 +151,7 @@ def main():
         ] = lines_available_for_comments
 
     clang_tidy_fixes = {}
-    # Apparently Clang-Tidy doesn't support multibyte encodings and measures offsets in bytes
-    with open(args.clang_tidy_fixes, encoding="latin_1") as file:
+    with open(args.clang_tidy_fixes, encoding="utf_8") as file:
         clang_tidy_fixes = yaml.full_load(file)
 
     if (

--- a/run_action.py
+++ b/run_action.py
@@ -152,7 +152,7 @@ def main():
 
     clang_tidy_fixes = {}
     with open(args.clang_tidy_fixes, encoding="utf_8") as file:
-        clang_tidy_fixes = yaml.full_load(file)
+        clang_tidy_fixes = yaml.safe_load(file)
 
     if (
         clang_tidy_fixes is None


### PR DESCRIPTION
After some research I figured out that PyYAML's `yaml.load()` family [expects the input](https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml) to be a valid UTF-8 or UTF-16 anyway (UTF-8 if there is no BOM), so it should be safe to use the `utf_8` codec to `open()` the `fixes.yml` file - if there are any invalid byte sequences in terms of UTF-8, YAML loading will fail anyway.

Also while `yaml.full_load()` is [a bit safer](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) than the deprecated `yaml.load()` function, `yaml.safe_load()` is still even more safe, because it allows only basic YAML tags, which should be enough for the Clang-Tidy.