### PR TITLE
Enable Dependabot for Docker and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -10,15 +10,15 @@ jobs:
   pylint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-      with:
-        python-version: 3.12
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pylint
-    - name: Analyze the code with pylint
-      run: |
-        pylint --fail-under=10.0 $(git ls-files '*.py')
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.12
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pylint
+      - name: Analyze the code with pylint
+        run: |
+          pylint --fail-under=10.0 $(git ls-files '*.py')


### PR DESCRIPTION
To keep them up-to-date.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates

Also a minor reformat of the `pylint.yaml` workflow to make it uniform with other workflow files.