### PR TITLE
Handle cases of pure text addition (except for adding a line to the end of the file)

### DIFF
--- a/run_action.py
+++ b/run_action.py
@@ -87,7 +87,7 @@ def get_pull_request_files(
 def get_pull_request_comments(
     github_api_url, github_token, github_api_timeout, repo, pull_request_id
 ):
-    """GitHub metadata generator about comments to the processed PR"""
+    """Generator of GitHub metadata about comments to the processed PR"""
 
     # Request a maximum of 100 pages (3000 files)
     for page in range(1, 101):


### PR DESCRIPTION
To handle replacements like this:

https://github.com/oleg-derevenetz/fheroes2/pull/165#pullrequestreview-1746852352

In this replacement initialization of `_displayMonitor` is moved before initialization of `_nearestScaling` like this:

```patch
+             , _displayMonitor( 0 )
              , _nearestScaling( false )
-             , _displayMonitor( 0 )
```

so it's a pure addition followed by pure removal.

The corresponding run URL is:

https://github.com/oleg-derevenetz/fheroes2/actions/runs/6972839758/job/18975746167#step:8:1