### PR TITLE
Remove redundant condition

### DIFF
--- a/run_action.py
+++ b/run_action.py
@@ -133,10 +133,7 @@ def generate_review_comments(
         for line_range in diff_line_ranges_per_file[file_path]:
             assert line_range.step == 1
 
-            if (
-                line_range.start <= start_line_num < line_range.stop
-                and end_line_num < line_range.stop
-            ):
+            if line_range.start <= start_line_num and end_line_num < line_range.stop:
                 return True
 
         return False


### PR DESCRIPTION
Minor improvement after #57.

The assertion at line 128 guarantees that `start_line_num` is no more than `end_line_num`, so if `end_line_num` is less than `line_range.stop`, then `start_line_num` is also less than `line_range.stop`, no need for separate `start_line_num < line_range.stop` check.