### PR TITLE
Replace Debian Buster (Debian 10) with Debian Bookworm (Debian 12)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.12.1-slim-bookworm
 
 RUN apt-get update
 RUN apt-get -y install jq


### PR DESCRIPTION
Buster-based Docker images are [not updated](https://github.com/docker-library/python/pull/822) anymore, and they don't have a chance to get new versions of Python.

Here is a test run of this image:

https://github.com/oleg-derevenetz/fheroes2/actions/runs/7187351207/job/19574722934