### PR TITLE
Document the required permissions in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ on: pull_request
 jobs:
   clang-tidy:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+    steps:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
@@ -149,6 +152,8 @@ jobs:
     # Trigger the job only when someone comments: run_clang_tidy
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'run_clang_tidy') }}
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -194,6 +199,8 @@ on: pull_request
 jobs:
   clang-tidy:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -241,6 +248,8 @@ jobs:
     # Trigger the job only if the previous (insecure) workflow completed successfully
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     steps:
     - name: Download analysis results
       uses: actions/github-script@v7


### PR DESCRIPTION
Many third-party actions document the permissions they need to do their job. This is considered good form.