### PR TITLE
README.md: remove extra permission from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,6 @@ on: pull_request
 jobs:
   clang-tidy:
     runs-on: ubuntu-22.04
-    permissions:
-      pull-requests: write
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Typical cut & paste typo. That workflow doesn't run this Action and doesn't require that permission.