### PR TITLE
also resolve conversations when dismissing reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
+      # auto-closing conversations requires the `contents` permission
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -154,6 +156,8 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
+      # auto-closing conversations requires the `contents` permission
+      contents: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -248,6 +252,8 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
+      # auto-closing conversations requires the `contents` permission
+      contents: write
     steps:
     - name: Download analysis results
       uses: actions/github-script@v7

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
-      # auto-closing conversations requires the `contents` permission
+      # OPTIONAL: auto-closing conversations requires the `contents` permission
       contents: write
     steps:
     - uses: actions/checkout@v4
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
-      # auto-closing conversations requires the `contents` permission
+      # OPTIONAL: auto-closing conversations requires the `contents` permission
       contents: write
     steps:
     - uses: actions/checkout@v4
@@ -252,7 +252,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
-      # auto-closing conversations requires the `contents` permission
+      # OPTIONAL: auto-closing conversations requires the `contents` permission
       contents: write
     steps:
     - name: Download analysis results

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'The path to repo when code is analyzed with clang-tidy; may set to "/__w" for users who run clang-tidy in a docker container'
     required: false
     default: '/home/runner/work'
+  auto_resolve_conversations:
+    description: 'Automatically resolve conversations when the clang-tidy issues are fixed'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -51,6 +55,7 @@ runs:
         INPUT_REQUEST_CHANGES: ${{ inputs.request_changes }}
         INPUT_SUGGESTIONS_PER_COMMENT: ${{ inputs.suggestions_per_comment }}
         INPUT_REPO_PATH_PREFIX: ${{ inputs.repo_path_prefix }}
+        INPUT_AUTO_RESOLVE_CONVERSATIONS: ${{ inputs.auto_resolve_conversations }}
 branding:
   icon: 'cpu'
   color: 'green'

--- a/action_launcher.bash
+++ b/action_launcher.bash
@@ -28,4 +28,5 @@ cd "$recreated_repo_dir"
   --repository "$GITHUB_REPOSITORY" \
   --repository-root "$recreated_repo_dir" \
   --request-changes "$INPUT_REQUEST_CHANGES" \
-  --suggestions-per-comment "$INPUT_SUGGESTIONS_PER_COMMENT"
+  --suggestions-per-comment "$INPUT_SUGGESTIONS_PER_COMMENT" \
+  --auto-resolve-conversations "$INPUT_AUTO_RESOLVE_CONVERSATIONS" \

--- a/run_action.py
+++ b/run_action.py
@@ -609,7 +609,7 @@ def close_conversation(thread_id, github_token, github_api_timeout):
     else:
         print(f"::error::GraphQL request failed: {response.status_code}")
     print(
-        "::error:: Failed to close conversation. See log for details and"
+        "::error:: Failed to close conversation. See log for details and "
         "https://github.com/platisd/clang-tidy-pr-comments/blob/master/README.md for help"
     )
     raise RuntimeError("Failed to close conversation.")

--- a/run_action.py
+++ b/run_action.py
@@ -671,7 +671,6 @@ def main():
         type=str,
         required=True,
         help="If 'true', then close any discussions opened by the Action",
-        help="Number of suggestions per comment",
     )
 
     args = parser.parse_args()

--- a/run_action.py
+++ b/run_action.py
@@ -565,7 +565,10 @@ def conversation_threads_to_close(repo, pr_number, github_token, github_api_time
                     yield thread
                     break
     else:
-        print("Error getting unresolved conversation threads:", response.status_code)
+        print(
+            f"::error::getting unresolved conversation threads: {response.status_code}"
+        )
+        raise RuntimeError("Failed to get unresolved conversation threads.")
 
 
 def close_conversation(thread_id, github_token, github_api_timeout):
@@ -609,6 +612,7 @@ def close_conversation(thread_id, github_token, github_api_timeout):
         "::error:: Failed to close conversation. See log for details and"
         "https://github.com/platisd/clang-tidy-pr-comments/blob/master/README.md for help"
     )
+    raise RuntimeError("Failed to close conversation.")
 
 
 def resolve_conversations(github_token, repo, pull_request_id, github_api_timeout):

--- a/run_action.py
+++ b/run_action.py
@@ -455,6 +455,7 @@ def dismiss_change_requests(
     pull_request_id,
     warning_comment_prefix,
     auto_resolve_conversations,
+    single_comment_marker,
 ):  # pylint: disable=too-many-arguments
     """Dismissing stale Clang-Tidy requests for changes"""
 
@@ -510,7 +511,7 @@ def dismiss_change_requests(
             repo=repo,
             pull_request_id=pull_request_id,
             github_api_timeout=github_api_timeout,
-            single_comment_marker=warning_comment_prefix,
+            single_comment_marker=single_comment_marker,
         )
 
 
@@ -740,8 +741,9 @@ def main():
             github_api_timeout,
             args.repository,
             args.pull_request_id,
-            warning_comment_prefix,
-            args.auto_resolve_conversations == "true",
+            warning_comment_prefix=warning_comment_prefix,
+            auto_resolve_conversations=args.auto_resolve_conversations == "true",
+            single_comment_marker=single_comment_marker,
         )
         return 0
 

--- a/run_action.py
+++ b/run_action.py
@@ -79,8 +79,7 @@ def get_pull_request_files(
         if not chunk:
             break
 
-        for item in chunk:
-            yield item
+        yield from chunk
 
 
 def get_pull_request_comments(
@@ -106,8 +105,7 @@ def get_pull_request_comments(
         if not chunk:
             break
 
-        for item in chunk:
-            yield item
+        yield from chunk
 
 
 def generate_review_comments(

--- a/run_action.py
+++ b/run_action.py
@@ -197,7 +197,8 @@ def generate_review_comments(
             "path": file_path,
             "line": end_line_num,
             "side": "RIGHT",
-            "body": f"{single_comment_marker} **{markdown(name)}** {single_comment_marker}\n{markdown(message)}",
+            "body": f"{single_comment_marker} **{markdown(name)}** {single_comment_marker}\n"
+            + markdown(message),
         }
 
         if start_line_num != end_line_num:

--- a/run_action.py
+++ b/run_action.py
@@ -672,9 +672,8 @@ def main():
     parser.add_argument(
         "--auto-resolve-conversations",
         type=str,
-        required=False,
-        # this matches the YAML schema for the input
-        default="false",
+        required=True,
+        help="If 'true', then close any discussions opened by the Action",
         help="Number of suggestions per comment",
     )
 


### PR DESCRIPTION
Resolving conversations is not available through the Rest API so we need to use the GraphQL one. This is the first time using it for me.
The mutation query needs the token to have `contents: write`. I found no documentation for this. Basically had to bisect the range of all possible perms to find that.
I've made the missing permission not fail the action to allow a "soft" upgrade path. An annotation is added to the github actions run. Not sure if that's a good path, it's not super obvious where that message comes from. Could use a link back to actual README?

[Example with full permission](https://github.com/renefritze/tidy_comments_test/pull/14)

[Example with missing permission](https://github.com/renefritze/tidy_comments_test/pull/15)