### PR TITLE
Add new `python_path` option to use existing Python installation

### DIFF
--- a/.github/workflows/pull-request-tests.yaml
+++ b/.github/workflows/pull-request-tests.yaml
@@ -38,3 +38,31 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           request_changes: false
           clang_tidy_fixes: build/fixes.yaml
+  check-action-with-custom-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        id: setup-python
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install dependencies
+        run: |
+          pip install clang-tidy==${CLANG_TIDY_VERSION} cmake==${CMAKE_VERSION}
+      - name: Configure Test project
+        run: |
+          mkdir build
+          cd build
+          cmake ../tests
+      - name: Run clang-tidy
+        run: |
+          cd build
+          cmake --build . --target clang-tidy
+      - name: Test Suggest Fixes
+        uses: ./
+        with:
+          # Use existing Python installation instead of installing a new one
+          python_path: ${{ steps.setup-python.outputs.python-path }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          request_changes: false
+          clang_tidy_fixes: build/fixes.yaml

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,15 @@ inputs:
     description: 'Automatically resolve conversations when the clang-tidy issues are fixed'
     required: false
     default: 'false'
+  python_path:
+    description: 'Path to a Python executable to use; if not set Python will be installed locally'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
     - name: Setup Python
+      if: ${{ !inputs.python_path }}
       uses: actions/setup-python@v5
       id: setup-python
       with:
@@ -38,7 +43,7 @@ runs:
         update-environment: false
     - name: Setup venv
       run: |
-        "${{ steps.setup-python.outputs.python-path }}" -m venv "${GITHUB_ACTION_PATH}/venv"
+        "${{ steps.setup-python.outputs.python-path || inputs.python_path }}" -m venv "${GITHUB_ACTION_PATH}/venv"
       shell: bash
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Resolves #84.

Not sure if the additional CI job for testing the option is needed, given that the other options aren't being tested either. FWIW, I tested the change in our workflow and everything works as intended!