### PR TITLE
Install jq before running action_launcher.bash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,8 @@ runs:
       run: |
         "${GITHUB_ACTION_PATH}/venv/bin/python" -m pip install -r "${GITHUB_ACTION_PATH}/requirements.txt"
       shell: bash
+    - name: Install jq
+      uses: dcarbone/install-jq-action@v2.1.0
     - name: Run action
       run: |
         "${GITHUB_ACTION_PATH}/action_launcher.bash"


### PR DESCRIPTION
Since `jq` is actually used in `action_launcher.bash`
let's install it to make sure it's always there