### PR TITLE
Close comment per file

### DIFF
--- a/run_action.py
+++ b/run_action.py
@@ -616,10 +616,11 @@ def conversation_threads_to_close(
 
     # Iterate through review threads
     for thread in data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]:
+        if thread["isResolved"]:
+            continue
         for comment in thread["comments"]["nodes"]:
             if (
                 comment["id"]
-                and thread["isResolved"] is False
                 # this actor here is somehow different from `github-actions[bot]`
                 # which we get through the Rest API
                 and comment["author"]["login"] == "github-actions"


### PR DESCRIPTION
As discussed under #95, we cannot always close active conversations reliably. However, there are some edge cases in which closing a conversation without disruption for the user is possible.

In this PR I introduce a check to verify whether a comment was posted on a file that does not have any proposed fix in the latest run of clang-tidy.